### PR TITLE
Handle more than 10 other actions for UIAlertView and UIActionSheet

### DIFF
--- a/Pod/Classes/UIActionSheet+DAAlert.h
+++ b/Pod/Classes/UIActionSheet+DAAlert.h
@@ -1,0 +1,19 @@
+//
+//  UIActionSheet+DAAlert.h
+//  DAAlertTest
+//
+//  Created by fritzgerald muiseroux on 13/05/15.
+//  Copyright (c) 2015 fritzgerald muiseroux. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@class DAAlertAction;
+@interface UIActionSheet (DAAlert)
+
+@property (copy, nonatomic) DAAlertAction *daCancelAction;
+@property (copy, nonatomic) DAAlertAction *daDestructiveAction;
+@property (copy, nonatomic) NSArray *daOtherActions;
+@property (copy, nonatomic) BOOL (^daValidationBlock)(NSArray *textFields);
+
+@end

--- a/Pod/Classes/UIActionSheet+DAAlert.m
+++ b/Pod/Classes/UIActionSheet+DAAlert.m
@@ -1,0 +1,54 @@
+//
+//  UIActionSheet+DAAlert.m
+//  DAAlertTest
+//
+//  Created by fritzgerald muiseroux on 13/05/15.
+//  Copyright (c) 2015 fritzgerald muiseroux. All rights reserved.
+//
+
+#import "UIActionSheet+DAAlert.h"
+#import <objc/runtime.h>
+
+@implementation UIActionSheet (DAAlert)
+
+- (DAAlertAction *)daCancelAction
+{
+    return objc_getAssociatedObject(self, @selector(daCancelAction));
+}
+
+- (void)setDaCancelAction:(DAAlertAction *)daCancelAction
+{
+    objc_setAssociatedObject(self, @selector(daCancelAction), daCancelAction, OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+- (DAAlertAction *)daDestructiveAction
+{
+    return objc_getAssociatedObject(self, @selector(daDestructiveAction));
+}
+
+- (void)setDaDestructiveAction:(DAAlertAction *)daDestructiveAction
+{
+    objc_setAssociatedObject(self, @selector(daDestructiveAction), daDestructiveAction, OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+- (NSArray *)daOtherActions
+{
+    return objc_getAssociatedObject(self, @selector(daOtherActions));
+}
+
+- (void)setDaOtherActions:(NSArray *)daOtherActions
+{
+    objc_setAssociatedObject(self, @selector(daOtherActions), daOtherActions, OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+- (BOOL (^)(NSArray *))daValidationBlock
+{
+    return objc_getAssociatedObject(self, @selector(daValidationBlock));
+}
+
+- (void)setDaValidationBlock:(BOOL (^)(NSArray *))daValidationBlock
+{
+    objc_setAssociatedObject(self, @selector(daValidationBlock), daValidationBlock, OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+@end

--- a/Pod/Classes/UIAlertView+DAAlert.h
+++ b/Pod/Classes/UIAlertView+DAAlert.h
@@ -1,0 +1,19 @@
+//
+//  UIAlertView+DAAlert.h
+//  DAAlertTest
+//
+//  Created by fritzgerald muiseroux on 13/05/15.
+//  Copyright (c) 2015 fritzgerald muiseroux. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@class DAAlertAction;
+@interface UIAlertView (DAAlert)
+
+@property (copy, nonatomic) DAAlertAction *daCancelAction;
+@property (copy, nonatomic) DAAlertAction *daDestructiveAction;
+@property (copy, nonatomic) NSArray *daOtherActions;
+@property (copy, nonatomic) BOOL (^daValidationBlock)(NSArray *textFields);
+
+@end

--- a/Pod/Classes/UIAlertView+DAAlert.m
+++ b/Pod/Classes/UIAlertView+DAAlert.m
@@ -1,0 +1,54 @@
+//
+//  UIAlertView+DAAlert.m
+//  DAAlertTest
+//
+//  Created by fritzgerald muiseroux on 13/05/15.
+//  Copyright (c) 2015 fritzgerald muiseroux. All rights reserved.
+//
+
+#import "UIAlertView+DAAlert.h"
+#import <objc/runtime.h>
+
+@implementation UIAlertView (DAAlert)
+
+- (DAAlertAction *)daCancelAction
+{
+    return objc_getAssociatedObject(self, @selector(daCancelAction));
+}
+
+- (void)setDaCancelAction:(DAAlertAction *)daCancelAction
+{
+    objc_setAssociatedObject(self, @selector(daCancelAction), daCancelAction, OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+- (DAAlertAction *)daDestructiveAction
+{
+    return objc_getAssociatedObject(self, @selector(daDestructiveAction));
+}
+
+- (void)setDaDestructiveAction:(DAAlertAction *)daDestructiveAction
+{
+    objc_setAssociatedObject(self, @selector(daDestructiveAction), daDestructiveAction, OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+- (NSArray *)daOtherActions
+{
+    return objc_getAssociatedObject(self, @selector(daOtherActions));
+}
+
+- (void)setDaOtherActions:(NSArray *)daOtherActions
+{
+    objc_setAssociatedObject(self, @selector(daOtherActions), daOtherActions, OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+- (BOOL (^)(NSArray *))daValidationBlock
+{
+    return objc_getAssociatedObject(self, @selector(daValidationBlock));
+}
+
+- (void)setDaValidationBlock:(BOOL (^)(NSArray *))daValidationBlock
+{
+    objc_setAssociatedObject(self, @selector(daValidationBlock), daValidationBlock, OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+@end


### PR DESCRIPTION
Remove other button limitation and use categories for DAAlertController
properties in UIAlertView and UIActionSheet
